### PR TITLE
Item's "tax" and "description" fields are optional

### DIFF
--- a/Lib/Paypal.php
+++ b/Lib/Paypal.php
@@ -814,8 +814,10 @@ class Paypal {
 			}
 			foreach ($order['items'] as $m => $item) {
 				$nvps["L_PAYMENTREQUEST_0_NAME$m"] = $item['name'];
-				$nvps["L_PAYMENTREQUEST_0_DESC$m"] = $item['description'];
-				$nvps["L_PAYMENTREQUEST_0_TAXAMT$m"] = $item['tax'];
+                if (array_key_exists("description", $item))
+    				$nvps["L_PAYMENTREQUEST_0_DESC$m"] = $item['description'];
+                if (array_key_exists("tax", $item))
+    				$nvps["L_PAYMENTREQUEST_0_TAXAMT$m"] = $item['tax'];
 				$nvps["L_PAYMENTREQUEST_0_AMT$m"] = $item['subtotal'];
 				$nvps["L_PAYMENTREQUEST_0_QTY$m"] = 1;
 			}


### PR DESCRIPTION
[1] https://developer.paypal.com/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/
