### PR TITLE
Composer installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ In your `Plugin` directory type:
 git clone -b master git://github.com/robmcvey/cakephp-paypal.git Paypal
 ```
 
+_[Composer]_
+
+```shell
+composer require robmcvey/cakephp-paypal
+```
+
+in the `composer.json` file of your project add
+```
+"extra": {
+        "installer-paths": {
+            "Plugin/Paypal": ["robmcvey/cakephp-paypal"]
+        }
+    },
+```
+The plugin will be installed in your Plugin directory.
+
 ### Usage
 
 Make sure the plugin is loaded in `app/Config/bootstrap.php`.

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
 	"type": "cakephp-plugin",
 	"require": {
 		"php": ">=5.2.8",
-		"ext-mcrypt": "*"
+		"ext-mcrypt": "*",
+		"composer/installers": "~1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
required composer installers, this makes it possible to install the plugin to a custom location like the cakephp Plugin directory. For more information see: https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md
